### PR TITLE
Fix initialization error when only OPENAI_API_KEY is configured

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,18 +1,24 @@
 import { AzureOpenAI, OpenAI } from 'openai';
 
-if (!process.env.AZURE_SECRET_KEY) {
-  throw new Error('Missing AZURE_SECRET_KEY environment variable');
-}
+export const createAzureOpenAI = () => {
+  if (!process.env.AZURE_SECRET_KEY) {
+    throw new Error('Missing AZURE_SECRET_KEY environment variable');
+  }
 
-if (!process.env.AZURE_ENDPOINT_URL) {
-  throw new Error('Missing AZURE_ENDPOINT_URL environment variable');
-}
+  if (!process.env.AZURE_ENDPOINT_URL) {
+    throw new Error('Missing AZURE_ENDPOINT_URL environment variable');
+  }
 
-export const openai = new AzureOpenAI({
-  apiKey: process.env.AZURE_SECRET_KEY,
-  endpoint: process.env.AZURE_ENDPOINT_URL,
-  apiVersion: '2024-10-21',
-});
+  return new AzureOpenAI({
+    apiKey: process.env.AZURE_SECRET_KEY,
+    endpoint: process.env.AZURE_ENDPOINT_URL,
+    apiVersion: '2024-10-21',
+  });
+};
+
+export const openai = process.env.AZURE_SECRET_KEY && process.env.AZURE_ENDPOINT_URL 
+  ? createAzureOpenAI()
+  : null;
 
 export const createDirectOpenAI = () => {
   if (!process.env.OPENAI_API_KEY) {


### PR DESCRIPTION
## Description

  This PR fixes a startup error that occurs when only `OPENAI_API_KEY` is set in the environment variables, without Azure OpenAI credentials.

  ## Problem

  The application currently throws an error on module import when `AZURE_SECRET_KEY` and `AZURE_ENDPOINT_URL` are not set, even if the user only wants
  to use the standard OpenAI API with `OPENAI_API_KEY`. This prevents the application from starting at all.

  Error: Missing AZURE_SECRET_KEY environment variable

  ## Solution

  - Modified `lib/openai.ts` to only check for Azure credentials when actually creating the Azure OpenAI client
  - Made the `openai` export conditional - it's `null` when Azure credentials are not available
  - Updated the API route to handle the case where `openai` is `null` and fall back to using the direct OpenAI client

  ## Changes

  - **lib/openai.ts**: Moved Azure credential validation inside a factory function and made the export conditional
  - **app/api/transliterate/route.ts**: Added handling for when only `OPENAI_API_KEY` is available

  ## Testing

  Tested with the following `.env.local` configurations:
  - [ ] Only `OPENAI_API_KEY` set (no more startup errors, uses OpenAI API)
  - [ ] All Azure credentials set (works as before)
  - [ ] Both Azure and OpenAI credentials set (works as before, uses Azure)

  ## Impact

  - Fixes startup error for users who only have `OPENAI_API_KEY`
  - No breaking changes for existing Azure OpenAI users
  - Makes the application more flexible in terms of API provider configuration=